### PR TITLE
Add support for scoped matchers

### DIFF
--- a/src/Makefile.propagate
+++ b/src/Makefile.propagate
@@ -1,5 +1,6 @@
 SELF_DIR = $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS = $(wildcard */Makefile)
+SUBDIRS_ = $(wildcard */Makefile)
+SUBDIRS = $(filter-out docs/Makefile,$(SUBDIRS_))
 
 include $(SELF_DIR)/Makefile.consts
 

--- a/src/core/neal.ml
+++ b/src/core/neal.ml
@@ -39,7 +39,12 @@ module Rule = struct
     file : string;
   }
 
-  type matcher = { node: string; predicate: exp option; body: stmt list; _uid: int }
+  type scope =
+    | Child of string
+    | Descendant of string
+    | Unscoped
+
+  type matcher = { scope: scope; node: string; predicate: exp option; body: stmt list; _uid: int }
 
   and stmt =
     | Action of call
@@ -105,6 +110,7 @@ module rec Ctx : sig
     provider: (module Provider.PROVIDER);
     reporters: (module Reporter.REPORTER) list;
     kind: string;
+    prop: string;
     props: (string * Absyn.absyn) list;
     depth: int;
     file: string;

--- a/src/core/rule/rule_lexer.mll
+++ b/src/core/rule/rule_lexer.mll
@@ -46,6 +46,9 @@ rule read = parse
 | "*" { STAR }
 | ":=" { ASGN }
 
+| ">>" { GTGT }
+| ">" { GT }
+
 | "true" { BOOL(true) }
 | "false" { BOOL(false) }
 

--- a/tests/matchers/input/test.swift
+++ b/tests/matchers/input/test.swift
@@ -1,0 +1,19 @@
+// RUN: %not %neal %args | %check
+
+class C {
+  let const = {
+    // CHECK: Child
+    // CHECK: Descendant
+    self.crash()
+  }
+
+  init() {
+    func f() {
+      let const = {
+        // CHECK-NOT: Child
+        // CHECK: Descendant
+        self.crash()
+      }
+    }
+  }
+}

--- a/tests/matchers/lit.local.cfg
+++ b/tests/matchers/lit.local.cfg
@@ -1,0 +1,3 @@
+# vi: ft=python
+
+config.suffixes = ['.swift']

--- a/tests/matchers/rules/test.rules
+++ b/tests/matchers/rules/test.rules
@@ -1,0 +1,19 @@
+rule Child {
+  Swift::ClassDeclaration {
+    ClassBody > ConstantDeclaration {
+      SelfExpression {
+        fail("Child")
+      }
+    }
+  }
+}
+
+rule Descendant {
+  Swift::ClassDeclaration {
+    ClassBody >> ConstantDeclaration {
+      SelfExpression {
+        fail("Descendant")
+      }
+    }
+  }
+}

--- a/tests/swift/input/test2.swift
+++ b/tests/swift/input/test2.swift
@@ -4,7 +4,7 @@ import Foundation
 
 class Foo {
   init() {
-    let _ = DisposeBag()
+    let _ = DisposeBag() // CHECK-NOT: error
   }
 }
 


### PR DESCRIPTION
Within the top-level matcher, nested matchers can restrict which
properties of the AST the wish to traverse and whether it should only
traverse immediate children (using `>`) or any node down the line (using
`>>`).

Close #2