### PR TITLE
Add reporter for xcode

### DIFF
--- a/src/reporters/xcode/Makefile
+++ b/src/reporters/xcode/Makefile
@@ -1,0 +1,4 @@
+LIBRARY = xcode
+LIBRARY_EXPORT_PREFIX = reporter
+
+include ../../Makefile.build

--- a/src/reporters/xcode/_tags
+++ b/src/reporters/xcode/_tags
@@ -1,0 +1,1 @@
+<*>: package(neal), coverage, annot, bin_annot

--- a/src/reporters/xcode/loc.ml
+++ b/src/reporters/xcode/loc.ml
@@ -1,0 +1,41 @@
+(* Copyright (c) 2017 Uber Technologies, Inc. *)
+(* *)
+(* Permission is hereby granted, free of charge, to any person obtaining a copy *)
+(* of this software and associated documentation files (the "Software"), to deal *)
+(* in the Software without restriction, including without limitation the rights *)
+(* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell *)
+(* copies of the Software, and to permit persons to whom the Software is *)
+(* furnished to do so, subject to the following conditions: *)
+(* *)
+(* The above copyright notice and this permission notice shall be included in *)
+(* all copies or substantial portions of the Software. *)
+(* *)
+(* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *)
+(* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, *)
+(* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE *)
+(* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *)
+(* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, *)
+(* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN *)
+(* THE SOFTWARE. *)
+
+open Neal
+
+let get_line' source offset =
+  let lines = Str.split (Str.regexp "\n") source in
+  let rec aux off lineno lines =
+    match lines with
+    | [] -> assert false
+    | line::lines' ->
+        let off' = String.length line + off + 1 in
+        if off' >= offset then
+          lineno else
+          aux off' (lineno + 1) lines'
+  in aux 0 1 lines
+
+let get_line ctx =
+  match ctx.Ctx.loc with
+  | None -> 0
+  | Some l ->
+      match l with
+      | Absyn.Off off -> get_line' ctx.Ctx.source off
+      | Absyn.Pos (l,c) -> l

--- a/src/reporters/xcode/myocamlbuild.ml
+++ b/src/reporters/xcode/myocamlbuild.ml
@@ -1,0 +1,22 @@
+(* Copyright (c) 2017 Uber Technologies, Inc. *)
+(* *)
+(* Permission is hereby granted, free of charge, to any person obtaining a copy *)
+(* of this software and associated documentation files (the "Software"), to deal *)
+(* in the Software without restriction, including without limitation the rights *)
+(* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell *)
+(* copies of the Software, and to permit persons to whom the Software is *)
+(* furnished to do so, subject to the following conditions: *)
+(* *)
+(* The above copyright notice and this permission notice shall be included in *)
+(* all copies or substantial portions of the Software. *)
+(* *)
+(* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *)
+(* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, *)
+(* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE *)
+(* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *)
+(* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, *)
+(* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN *)
+(* THE SOFTWARE. *)
+
+open Ocamlbuild_plugin
+let () = dispatch Bisect_ppx_plugin.dispatch

--- a/src/reporters/xcode/opam
+++ b/src/reporters/xcode/opam
@@ -1,0 +1,10 @@
+opam-version: "1.2"
+name: "neal-reporter-xcode"
+version: "0.1"
+maintainer: "Tadeu Zagallo <tadeu@uber.com>"
+authors: [ "Tadeu Zagallo <tadeu@uber.com>" ]
+license: "MIT"
+build: []
+depends: [
+  "neal"
+]

--- a/src/reporters/xcode/xcode.mldylib
+++ b/src/reporters/xcode/xcode.mldylib
@@ -1,0 +1,2 @@
+Xcode_reporter
+Loc

--- a/src/reporters/xcode/xcode.mlpack
+++ b/src/reporters/xcode/xcode.mlpack
@@ -1,0 +1,2 @@
+Xcode_reporter
+Loc

--- a/src/reporters/xcode/xcode_reporter.ml
+++ b/src/reporters/xcode/xcode_reporter.ml
@@ -1,0 +1,33 @@
+(* Copyright (c) 2017 Uber Technologies, Inc. *)
+(* *)
+(* Permission is hereby granted, free of charge, to any person obtaining a copy *)
+(* of this software and associated documentation files (the "Software"), to deal *)
+(* in the Software without restriction, including without limitation the rights *)
+(* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell *)
+(* copies of the Software, and to permit persons to whom the Software is *)
+(* furnished to do so, subject to the following conditions: *)
+(* *)
+(* The above copyright notice and this permission notice shall be included in *)
+(* all copies or substantial portions of the Software. *)
+(* *)
+(* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *)
+(* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, *)
+(* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE *)
+(* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *)
+(* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, *)
+(* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN *)
+(* THE SOFTWARE. *)
+
+module Ctx = Neal.Ctx
+module R = Neal.Reporter
+
+let () = R.register(module struct
+  let name = "xcode"
+
+  let report severity ctx (R.Suggestion fix) =
+    let Neal.Rule.Rule(name, _, _) = ctx.Ctx.rule in
+    let line = Loc.get_line ctx in
+    let severity' = R.string_of_severity severity in
+
+    Printf.printf "%s:%d: %s: %s (%s)\n" ctx.Ctx.file line severity' fix name
+end)


### PR DESCRIPTION
Adds a reporter to show the results in Xcode:

<img width="532" alt="screen shot 2018-02-16 at 14 32 41" src="https://user-images.githubusercontent.com/194417/36309795-490a63bc-1326-11e8-9101-92a87a54df7a.png">

Usage in xcode Buildphase:

/usr/local/bin/neal --reporter xcode $SRCROOT || true

As this is the first ever code I have written in OCAML feel free to point out anything unusual.