### PR TITLE
Fix bisect_ppx dependency

### DIFF
--- a/src/Makefile.consts
+++ b/src/Makefile.consts
@@ -30,7 +30,7 @@ ifdef LIB_PATH
 endif
 endif
 
-OCAMLBUILD := $(COVERAGE) ocamlbuild $(_LIB_PATH) -use-ocamlfind -plugin-tag 'package(bisect_ppx.ocamlbuild)'
+OCAMLBUILD := $(COVERAGE) ocamlbuild $(_LIB_PATH) -use-ocamlfind -plugin-tag 'package(bisect_ppx-ocamlbuild)'
 
 $(NEAL):
 	@make -C $(SELF_DIR) build

--- a/src/opam/opam
+++ b/src/opam/opam
@@ -17,6 +17,7 @@ depends: [
   "menhir"
   "yojson"
   "bisect_ppx"
+  "bisect_ppx-ocamlbuild"
 ]
 build: [
   [make "-C" "core" "build" "LIB_PATH=%{prefix}%/lib/neal" "NATIVE=1"]


### PR DESCRIPTION
Currently I am unable to build master as is, getting this error:
```
smiller[~/git/neal]master⇒  make build
ocamlbuild  -use-ocamlfind -plugin-tag 'package(bisect_ppx.ocamlbuild)' main.byte
+ ocamlfind ocamlopt -package unix -package ocamlbuild -linkpkg -package bisect_ppx.ocamlbuild myocamlbuild.ml /Users/smiller/.opam/4.04.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
ocamlfind: Package `bisect_ppx.ocamlbuild' not found
Command exited with code 2.
Compilation unsuccessful after building 1 target (0 cached) in 00:00:00.
make[2]: *** [build] Error 10
make[1]: *** [core.build] Error 2
make: *** [src.build] Error 2
```

After some research it seems that the package name for the bisect_ppx build plugin is [bisect_ppx-ocamlbuild](https://opam.ocaml.org/packages/bisect_ppx-ocamlbuild/bisect_ppx-ocamlbuild.1.0.1/). This update fixed the build for me. I verified that neal works as expected, tests pass, and coverage is still working.