### PR TITLE
Add a `runonly` directive in addition to the existing `skip`

### DIFF
--- a/src/core/directives/directive.ml
+++ b/src/core/directives/directive.ml
@@ -46,6 +46,8 @@ let is_ignored ctx line directives =
     | Some line, (l, Skip (AllRules, Local d, _)) when direction l d = line -> true
     | _, (_, Skip (SomeRules rules, Global, _)) when List.mem rule_name rules -> true
     | Some line, (l, Skip (SomeRules rules, Local d, _)) when List.mem rule_name rules && direction l d = line -> true
+    | _, (_, RunOnly (SomeRules rules, Global, _)) when not (List.mem rule_name rules) -> true
+    | Some line, (l, RunOnly (SomeRules rules, Local d, _)) when (not (List.mem rule_name rules)) && direction l d = line -> true
     | _, (_, s) -> false
   in List.exists aux directives
 

--- a/src/core/directives/skip_absyn.ml
+++ b/src/core/directives/skip_absyn.ml
@@ -22,7 +22,7 @@ type direction = This | Next | Prev
 type scope = Global | Local of direction
 type rules = AllRules | SomeRules of string list
 type excuse = string
-type skip = Skip of rules * scope * excuse
+type action = Skip of rules * scope * excuse | RunOnly of rules * scope * excuse
 type line_number = int
 type 'a directive = (line_number * 'a)
 
@@ -47,5 +47,6 @@ let print_scope out = function
   | Global -> Printf.fprintf out "this file"
   | Local d -> Printf.fprintf out "%a line" print_direction d
 
-let print_skip (Skip (rules, scope, excuse)) =
-  Printf.printf "NEAL: skip %a on %a because %s\n" print_rules rules print_scope scope excuse
+let print_skip action = function
+  | Skip (rules, scope, excuse) -> Printf.printf "NEAL: skip %a on %a because %s\n" print_rules rules print_scope scope excuse
+  | RunOnly (rules, scope, excuse) -> Printf.printf "NEAL: runonly %a on %a because %s\n" print_rules rules print_scope scope excuse

--- a/src/core/directives/skip_lexer.mll
+++ b/src/core/directives/skip_lexer.mll
@@ -35,6 +35,7 @@ rule read = parse
 | "previous" { PREV }
 | "rules" { RULES }
 | "skip" { SKIP }
+| "runonly" { RUNONLY }
 | "the" { THE }
 | "this" { THIS }
 

--- a/src/core/directives/skip_parser.mly
+++ b/src/core/directives/skip_parser.mly
@@ -33,6 +33,7 @@
 %token LINE
 %token FILE
 %token SKIP
+%token RUNONLY
 %token COLON
 %token NEAL
 %token THE
@@ -41,7 +42,7 @@
 %token <string> ID
 %token <string> BECAUSE
 
-%start <Skip_absyn.skip> parse
+%start <Skip_absyn.action> parse
 
 %%
 
@@ -71,4 +72,6 @@ global_context: THIS FILE { Global }
 
 context: line_context | global_context { $1 }
 
-parse: NEAL COLON SKIP pattern ON context BECAUSE EOF { Skip ($4, $6, $7) }
+parse:
+  | NEAL COLON SKIP pattern ON context BECAUSE EOF { Skip ($4, $6, $7) }
+  | NEAL COLON RUNONLY pattern ON context BECAUSE EOF { RunOnly ($4, $6, $7) }

--- a/tests/integration/input/runonly.swift
+++ b/tests/integration/input/runonly.swift
@@ -1,0 +1,18 @@
+// RUN: %not %neal %args | %check
+
+// NEAL: runonly X, Bang and NSLog on this file because I need to test it
+
+print("")
+
+x! // CHECK-NEXT-L: error: No force unwrap
+
+// NEAL: runonly X on the next line because I need to test it
+x!
+
+x! // CHECK-NEXT-L: error: No force unwrap
+// NEAL: runonly Bang on the previous line because I need to test it
+
+NSLog("astr") // CHECK-NEXT-L: warning: Don't call `NSLog`
+
+// NEAL: runonly Bang on the next line because I need to test it
+NSLog("astr") // CHECK-NOT-L: warning: Don't call `NSLog`

--- a/tests/integration/rules/test.rules
+++ b/tests/integration/rules/test.rules
@@ -19,3 +19,14 @@ rule Print {
     test2: expect_warn("print()")
   }
 }
+
+rule NSLog {
+  Swift::CallExpression where Callee == "NSLog" {
+    warn("Don't call `NSLog`")
+  }
+
+  tests {
+    test1: expect_ok("print(\"astr\")")
+    test2: expect_warn("NSLog(\"astr\")")
+  }
+}


### PR DESCRIPTION
Today we have a directive to skip rules on a file or certain lines (`NEAL: skip <rules> <scope> <reason>`). This diff adds a runonly directive to only check certain rules on a file or certain lines (`NEAL: runonly <rules> <scope> <reason>`). This could be useful for generated files where we don't want to run the full rule set but some specific rules should still be respected. 

### Alternative Proposals

- Call this a `skip all except` directive used like: `NEAL: skip all except <rules> <scope> <reason>`
  - Would involve renaming most of internals and updating the parsing to check for the new prefix & only for rules list rather than rules list & "all rules".
- Name this `check only`