### PR TITLE
Allows to use keywords other than inout, var, and let in function calls

### DIFF
--- a/src/providers/swift/parsing/parser.ml
+++ b/src/providers/swift/parsing/parser.ml
@@ -1339,7 +1339,7 @@ and trailingClosure ~allowTrailingClosure () =
 (*| function-call-argument -> operator | identifier ":" operator |*)
 and functionCallArgument () =
   mkNode "FunctionCallArgument"
-  <:> mkOptProp "Label" (identifier () <* wchar ':')
+  <:> mkOptProp "Label" (paramName () <* wchar ':')
   <:> (
     mkProp "Expression" (fix expression)
     <|> mkPropE "Operator" operator

--- a/tests/swift_parser/valid/function_call.swift
+++ b/tests/swift_parser/valid/function_call.swift
@@ -1,0 +1,7 @@
+// RUN: %neal-swift
+
+final class Foo {
+    func bar() {
+        button.addTarget(self, action: #selector(baz), for: .touchUpInside)
+    }
+}


### PR DESCRIPTION
According to [the documentation](https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html#):

> Keywords other than inout, var, and let can be used as parameter names in a function declaration or function call without being escaped with backticks.

This PR allows such behaviour. 