### PR TITLE
Fixes annotation parser

### DIFF
--- a/src/providers/swift/parsing/parser.ml
+++ b/src/providers/swift/parsing/parser.ml
@@ -3088,19 +3088,23 @@ and balancedTokens _ =
 (*| balanced-token -> Any identifier, keyword, literal, or operator |*)
 (*| balanced-token -> Any punctuation except "(" , ")" , "[" , "]" , "{" , or "}" |*)
 and balancedToken _ =
-  wchar '(' *> fix balancedTokens <* wchar '*'
+  wchar '(' *> fix balancedTokens <* wchar ')'
   <|>
   wchar '[' *> fix balancedTokens <* wchar ']'
   <|>
   wchar '{' *> fix balancedTokens <* wchar '}'
+  <|>
+  identifier () (*| this includes keywords |*)
+  <|>
+  literal ()
+  <|>
+  operator ()
   <|> (
     pos >>= fun pos ->
       many1(fun () -> satisfy(function
-        | '(' | ')'
-        | '[' | ']'
-        | '{' | '}'
-        -> false
-        | _ -> true
+        | '.' | ',' | ':' | ';' | '=' | '@' | '#' | '&' | '`' | '?' | '!'
+        -> true
+        | _ -> false
       )) >>| fun chars ->
         NodeHolder(pos, string_of_chars chars)
   )

--- a/tests/swift_parser/valid/annotation.swift
+++ b/tests/swift_parser/valid/annotation.swift
@@ -1,0 +1,7 @@
+// RUN: %neal-swift
+
+final class Foo {
+    @available(*, unavailable, message: "Unavailable, use baz()")
+    func bar() {
+    }
+}


### PR DESCRIPTION
Annotation parser used to fail on constructions like
```
    @available(*, unavailable, message: "Unavailable, use baz()")
```

This PR changes the implementation to match swift grammar.