### PR TITLE
Use realpath from Unix instead of Core.Filename which has been deprecated

### DIFF
--- a/src/core/driver/fs.ml
+++ b/src/core/driver/fs.ml
@@ -20,7 +20,7 @@
 
 module StringSet = Set.Make(String)
 
-let realpath = Core.Filename.realpath
+let realpath = Unix.realpath
 
 let join_path dir path =
   Filename.concat dir path |> realpath

--- a/src/core/neal.ml
+++ b/src/core/neal.ml
@@ -230,14 +230,14 @@ end
 module Utils = struct
   let neal_root =
   IFDEF RELATIVE_LIB_PATH THEN
-    let exec_path = Core.Filename.realpath Sys.executable_name in
+    let exec_path = Unix.realpath Sys.executable_name in
     let _build = Filename.dirname exec_path in
     Filename.concat _build RELATIVE_LIB_PATH
   ELSE
     IFDEF LIB_PATH THEN
       LIB_PATH
     ELSE
-      let exec_path = Core.Filename.realpath Sys.executable_name in
+      let exec_path = Unix.realpath Sys.executable_name in
       let _build = Filename.dirname exec_path in
       let neal = Filename.dirname _build in
       Filename.dirname neal


### PR DESCRIPTION
When trying to build locally, it was failing due to the usage of `Core.Filename.realpath`, which appears to have been deprecated and moved to `Unix.realpath`