### PR TITLE
Add support for JavaScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 env*
 *.pickle
 _coverage/
+src/providers/helpers/dump_javascript_ast.js

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ setup-buildonly:
 	opam update
 	opam pin add neal src -n -y
 	opam install --deps-only neal -y
+	cd src/providers/javascript/helper && npm install
 
 install-brew:
 	# install the main binary

--- a/src/Makefile.propagate
+++ b/src/Makefile.propagate
@@ -5,13 +5,13 @@ SUBDIRS = $(filter-out docs/Makefile,$(SUBDIRS_))
 include $(SELF_DIR)/Makefile.consts
 
 .PHONY: build
-build: $(patsubst %/Makefile,%.build,$(SUBDIRS))
+build:: $(patsubst %/Makefile,%.build,$(SUBDIRS))
 
 .PHONY: clean
-clean: $(patsubst %/Makefile,%.clean,$(SUBDIRS))
+clean:: $(patsubst %/Makefile,%.clean,$(SUBDIRS))
 
 .PHONY: test
-test: $(NEAL) $(patsubst %/Makefile,%.test,$(SUBDIRS))
+test:: $(NEAL) $(patsubst %/Makefile,%.test,$(SUBDIRS))
 	@true
 
 %.build:

--- a/src/providers/javascript/Makefile
+++ b/src/providers/javascript/Makefile
@@ -1,0 +1,5 @@
+LIBRARY = javascript
+LIBRARY_EXPORT_PREFIX = provider
+
+include ../../Makefile.build
+include ../../Makefile.propagate

--- a/src/providers/javascript/_tags
+++ b/src/providers/javascript/_tags
@@ -1,0 +1,1 @@
+true: package(neal, yojson), coverage, annot, bin_annot

--- a/src/providers/javascript/helper/Makefile
+++ b/src/providers/javascript/helper/Makefile
@@ -1,0 +1,7 @@
+build:
+	yarn build
+	cp _build/dump_javascript_ast.js ../../helpers
+	chmod +x ../../helpers/dump_javascript_ast.js
+
+clean:
+	rm -rf _build

--- a/src/providers/javascript/helper/package-lock.json
+++ b/src/providers/javascript/helper/package-lock.json
@@ -1,0 +1,997 @@
+{
+  "name": "@neal/js-provider-helper",
+  "version": "0.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@neal/js-provider-helper",
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "^21.1.0",
+        "@rollup/plugin-node-resolve": "^13.2.1",
+        "babylon": "^6.18.0",
+        "rollup": "^2.70.2",
+        "rollup-plugin-preserve-shebang": "^1.0.1",
+        "rollup-plugin-terser": "^7.0.2"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.16.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.17.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "21.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.38.3"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "13.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.42.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.51",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.24",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.17.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/babylon": {
+      "version": "6.18.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "babylon": "bin/babylon.js"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "26.6.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.70.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-preserve-shebang": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.25.7"
+      }
+    },
+    "node_modules/rollup-plugin-terser": {
+      "version": "7.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/serialize-javascript": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.3",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.12.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "ISC"
+    }
+  },
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.16.7",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.16.7"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.17.9",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@rollup/plugin-commonjs": {
+      "version": "21.1.0",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "13.2.1",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "0.0.39",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "dev": true
+        }
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.51",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "17.0.24",
+      "dev": true
+    },
+    "@types/resolve": {
+      "version": "1.17.1",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "acorn": {
+      "version": "8.7.0",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "3.2.0",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.20.3",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "2.0.2",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.0",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.8.1",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "is-reference": {
+      "version": "1.2.1",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
+    },
+    "jest-worker": {
+      "version": "26.6.2",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "magic-string": {
+      "version": "0.25.9",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "resolve": {
+      "version": "1.22.0",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "rollup": {
+      "version": "2.70.2",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-preserve-shebang": {
+      "version": "1.0.1",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.25.7"
+      }
+    },
+    "rollup-plugin-terser": {
+      "version": "7.0.2",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "4.0.0",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "source-map": {
+      "version": "0.7.3",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "dev": true
+        }
+      }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "terser": {
+      "version": "5.12.1",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.20"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "dev": true
+    }
+  }
+}

--- a/src/providers/javascript/helper/package.json
+++ b/src/providers/javascript/helper/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@neal/js-provider-helper",
+  "version": "0.0.0",
+  "private": true,
+  "description": "JavaScript provider for NEAL",
+  "main": "index.js",
+  "scripts": {
+    "build": "rollup -c rollup.config.js"
+  },
+  "author": "Tadeu Zagallo <tadeuzagallo@gmail.com>",
+  "license": "MIT",
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^21.1.0",
+    "@rollup/plugin-node-resolve": "^13.2.1",
+    "babylon": "^6.18.0",
+    "rollup": "^2.70.2",
+    "rollup-plugin-preserve-shebang": "^1.0.1",
+    "rollup-plugin-terser": "^7.0.2"
+  },
+  "dependencies": {}
+}

--- a/src/providers/javascript/helper/rollup.config.js
+++ b/src/providers/javascript/helper/rollup.config.js
@@ -1,0 +1,20 @@
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import shebang from 'rollup-plugin-preserve-shebang';
+import { terser } from 'rollup-plugin-terser';
+
+export default {
+  input: 'src/index.js',
+  external: ['fs'],
+  output: {
+    file: '_build/dump_javascript_ast.js',
+    format: 'cjs',
+    exports: 'default',
+  },
+  plugins: [
+    shebang(),
+    resolve(),
+    commonjs(),
+    terser(),
+  ]
+};

--- a/src/providers/javascript/helper/src/index.js
+++ b/src/providers/javascript/helper/src/index.js
@@ -1,0 +1,9 @@
+#! /usr/bin/env node
+
+var babylon = require("babylon");
+var fs = require("fs");
+
+var source = fs.readFileSync(process.stdin.fd, 'utf-8');
+var ast = babylon.parse(source);
+
+console.log(JSON.stringify(ast))

--- a/src/providers/javascript/javascript.ml
+++ b/src/providers/javascript/javascript.ml
@@ -1,0 +1,69 @@
+open Neal
+
+exception Type_error
+
+let to_string = function
+  | `String s -> s
+  | _ -> raise Type_error
+
+let to_int = function
+  | `Int i -> i
+  | _ -> raise Type_error
+
+let assoc key = function
+  | `Assoc props -> List.assoc key props
+  | _ -> raise Type_error
+
+let get_kind props =
+  List.assoc "type" props
+  |> to_string
+  |> String.capitalize_ascii
+
+let get_loc (props : (string * Yojson.Safe.t) list) =
+  try
+    List.assoc "loc" props
+    |> assoc "start"
+    |> fun x ->
+        Absyn.Pos (assoc "line" x |> to_int, assoc "column" x |> to_int)
+  with Not_found ->
+    Absyn.Pos (0, 0)
+
+let rec get_props props =
+  List.fold_left (fun ps (k,v) ->
+    match k with
+    | "start" | "end" | "loc" | "tokens" -> ps
+    | k -> (String.capitalize_ascii k, absyn_of_json v) :: ps
+  ) [] props
+
+and absyn_of_json x =
+  try
+    match x with
+  | `Assoc props -> Absyn.Node (get_kind props, get_loc props, get_props props)
+  | `Int i -> Absyn.Int i
+  | `String s -> Absyn.String s
+  | `Bool b -> Absyn.Bool b
+  | `Null -> Absyn.Null | `List l -> Absyn.List (List.map absyn_of_json l)
+  | _ -> raise Type_error
+  with Not_found ->
+    print_string "WTF";
+    print_string (Yojson.Safe.show x);
+    raise Type_error
+
+let exec_name = Neal.Utils.relative_path "providers/helpers/dump_javascript_ast.js"
+
+let parse _ source =
+  let stdout, stdin = Unix.open_process exec_name in
+  output_string stdin source;
+  close_out stdin;
+  let json = Yojson.Safe.from_channel stdout in
+  close_in stdout;
+  let _ = Unix.close_process (stdout, stdin) in
+  absyn_of_json json
+
+let () = Provider.register(module struct
+  let name = "JavaScript"
+  let extensions = [".js"]
+  let parse = parse
+  let exported_macros = []
+  let exported_actions = []
+end)

--- a/src/providers/javascript/myocamlbuild.ml
+++ b/src/providers/javascript/myocamlbuild.ml
@@ -1,0 +1,2 @@
+open Ocamlbuild_plugin
+let () = dispatch Bisect_ppx_plugin.dispatch

--- a/tests/javascript/input/simple.js
+++ b/tests/javascript/input/simple.js
@@ -1,0 +1,9 @@
+// RUN: %not %neal %args | %check
+
+async function test(array) {
+  for (let f of array) {
+
+    // CHECK: error: Do not use `await` inside loops
+    await f()
+  }
+}

--- a/tests/javascript/lit.local.cfg
+++ b/tests/javascript/lit.local.cfg
@@ -1,0 +1,3 @@
+# vi: ft=python
+
+config.suffixes = ['.js']

--- a/tests/javascript/rules/test.rules
+++ b/tests/javascript/rules/test.rules
@@ -1,0 +1,7 @@
+rule no_await_in_loops {
+  JavaScript::ForOfStatement {
+    AwaitExpression  {
+      fail("Do not use `await` inside loops")
+    }
+  }
+}


### PR DESCRIPTION
I wrote a very simple JS provider that is just a thin wrapper around `babylon`, similar to how the python provider works. To avoid having to copy all the dependencies when installing NEAL, I added a build step to generated a single self-contained JS file.